### PR TITLE
PlayGo: Hardcoded stub fix for the infinite download prompt in RB4 base (Title is still installing)

### DIFF
--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -132,6 +132,7 @@ public:
 static ConfigEntry<int> volumeSlider(100);
 static ConfigEntry<bool> isNeo(false);
 static ConfigEntry<bool> isDevKit(false);
+static ConfigEntry<bool> enablePlayGoFix(false);
 static ConfigEntry<int> extraDmemInMbytes(0);
 static ConfigEntry<bool> isPSNSignedIn(false);
 static ConfigEntry<bool> isTrophyPopupDisabled(false);
@@ -443,6 +444,10 @@ bool showSplash() {
     return isShowSplash.get();
 }
 
+bool enablePlayGoFix() {
+    return enablePlayGoFix.get();
+}
+
 string sideTrophy() {
     return isSideTrophy.get();
 }
@@ -584,6 +589,10 @@ void setCollectShaderForDebug(bool enable, bool is_game_specific) {
 
 void setShowSplash(bool enable, bool is_game_specific) {
     isShowSplash.set(enable, is_game_specific);
+}
+
+void setEnablePlayGoFix(bool enable, bool is_game_specific) {
+    enablePlayGoFix.set(enable, is_game_specific);
 }
 
 void setSideTrophy(string side, bool is_game_specific) {
@@ -900,6 +909,7 @@ void load(const std::filesystem::path& path, bool is_game_specific) {
         userName.setFromToml(general, "userName", is_game_specific);
         isShowSplash.setFromToml(general, "showSplash", is_game_specific);
         isSideTrophy.setFromToml(general, "sideTrophy", is_game_specific);
+        enablePlayGoFix.setFromToml(general, "enablePlayGoFix", is_game_specific);
         compatibilityData = toml::find_or<bool>(general, "compatibilityEnabled", compatibilityData);
         checkCompatibilityOnStartup = toml::find_or<bool>(general, "checkCompatibilityOnStartup",
                                                           checkCompatibilityOnStartup);
@@ -1097,6 +1107,7 @@ void save(const std::filesystem::path& path, bool is_game_specific) {
     chooseHomeTab.setTomlValue(data, "General", "chooseHomeTab", is_game_specific);
     isShowSplash.setTomlValue(data, "General", "showSplash", is_game_specific);
     isSideTrophy.setTomlValue(data, "General", "sideTrophy", is_game_specific);
+    enablePlayGoFix.setTomlValue(data, "General", "enablePlayGoFix", is_game_specific);
     isNeo.setTomlValue(data, "General", "isPS4Pro", is_game_specific);
     isDevKit.setTomlValue(data, "General", "isDevKit", is_game_specific);
     if (is_game_specific) {

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -132,7 +132,7 @@ public:
 static ConfigEntry<int> volumeSlider(100);
 static ConfigEntry<bool> isNeo(false);
 static ConfigEntry<bool> isDevKit(false);
-static ConfigEntry<bool> enablePlayGoFix(false);
+static ConfigEntry<bool> isEnablePlayGoFix(false);
 static ConfigEntry<int> extraDmemInMbytes(0);
 static ConfigEntry<bool> isPSNSignedIn(false);
 static ConfigEntry<bool> isTrophyPopupDisabled(false);
@@ -445,7 +445,7 @@ bool showSplash() {
 }
 
 bool enablePlayGoFix() {
-    return enablePlayGoFix.get();
+    return isEnablePlayGoFix.get();
 }
 
 string sideTrophy() {
@@ -592,7 +592,7 @@ void setShowSplash(bool enable, bool is_game_specific) {
 }
 
 void setEnablePlayGoFix(bool enable, bool is_game_specific) {
-    enablePlayGoFix.set(enable, is_game_specific);
+    isEnablePlayGoFix.set(enable, is_game_specific);
 }
 
 void setSideTrophy(string side, bool is_game_specific) {
@@ -909,7 +909,7 @@ void load(const std::filesystem::path& path, bool is_game_specific) {
         userName.setFromToml(general, "userName", is_game_specific);
         isShowSplash.setFromToml(general, "showSplash", is_game_specific);
         isSideTrophy.setFromToml(general, "sideTrophy", is_game_specific);
-        enablePlayGoFix.setFromToml(general, "enablePlayGoFix", is_game_specific);
+        isEnablePlayGoFix.setFromToml(general, "enablePlayGoFix", is_game_specific);
         compatibilityData = toml::find_or<bool>(general, "compatibilityEnabled", compatibilityData);
         checkCompatibilityOnStartup = toml::find_or<bool>(general, "checkCompatibilityOnStartup",
                                                           checkCompatibilityOnStartup);
@@ -1107,7 +1107,7 @@ void save(const std::filesystem::path& path, bool is_game_specific) {
     chooseHomeTab.setTomlValue(data, "General", "chooseHomeTab", is_game_specific);
     isShowSplash.setTomlValue(data, "General", "showSplash", is_game_specific);
     isSideTrophy.setTomlValue(data, "General", "sideTrophy", is_game_specific);
-    enablePlayGoFix.setTomlValue(data, "General", "enablePlayGoFix", is_game_specific);
+    isEnablePlayGoFix.setTomlValue(data, "General", "enablePlayGoFix", is_game_specific);
     isNeo.setTomlValue(data, "General", "isPS4Pro", is_game_specific);
     isDevKit.setTomlValue(data, "General", "isDevKit", is_game_specific);
     if (is_game_specific) {

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -55,6 +55,8 @@ bool collectShadersForDebug();
 void setCollectShaderForDebug(bool enable, bool is_game_specific = false);
 bool showSplash();
 void setShowSplash(bool enable, bool is_game_specific = false);
+bool enablePlayGoFix();
+void setEnablePlayGoFix(bool enable, bool is_game_specific = false);    
 std::string sideTrophy();
 void setSideTrophy(std::string side, bool is_game_specific = false);
 bool nullGpu();

--- a/src/core/libraries/playgo/playgo.cpp
+++ b/src/core/libraries/playgo/playgo.cpp
@@ -153,18 +153,12 @@ s32 PS4_SYSV_ABI scePlayGoGetLocus(OrbisPlayGoHandle handle, const OrbisPlayGoCh
     if (!playgo) {
         return ORBIS_PLAYGO_ERROR_NOT_INITIALIZED;
     }
-    if (playgo->GetPlaygoHeader().file_size == 0) {
-        return ORBIS_PLAYGO_ERROR_NOT_SUPPORT_PLAYGO;
+
+    // Force LocalFast status for all queried chunks
+    for (uint32_t i = 0; i < numberOfEntries; i++) {
+        outLoci[i] = OrbisPlayGoLocus::LocalFast;
     }
 
-    for (int i = 0; i < numberOfEntries; i++) {
-        if (chunkIds[i] < playgo->chunks.size()) {
-            outLoci[i] = OrbisPlayGoLocus::LocalFast;
-        } else {
-            outLoci[i] = OrbisPlayGoLocus::NotDownloaded;
-            return ORBIS_PLAYGO_ERROR_BAD_CHUNK_ID;
-        }
-    }
     return ORBIS_OK;
 }
 
@@ -185,25 +179,10 @@ s32 PS4_SYSV_ABI scePlayGoGetProgress(OrbisPlayGoHandle handle, const OrbisPlayG
     if (!playgo) {
         return ORBIS_PLAYGO_ERROR_NOT_INITIALIZED;
     }
-    if (playgo->GetPlaygoHeader().file_size == 0) {
-        return ORBIS_PLAYGO_ERROR_BAD_CHUNK_ID;
-    }
 
-    outProgress->progressSize = 0;
-    outProgress->totalSize = 0;
-
-    u64 total_size = 0;
-    for (u32 i = 0; i < numberOfEntries; i++) {
-        u32 chunk_id = chunkIds[i];
-        if (chunk_id < playgo->chunks.size()) {
-            total_size += playgo->chunks[chunk_id].total_size;
-        } else {
-            return ORBIS_PLAYGO_ERROR_BAD_CHUNK_ID;
-        }
-    }
-
-    outProgress->progressSize = total_size;
-    outProgress->totalSize = total_size;
+    // Report 100% progress with 1 GB fixed size
+    outProgress->progressSize = 1073741824; // 1 GB
+    outProgress->totalSize = 1073741824;
 
     return ORBIS_OK;
 }

--- a/src/core/libraries/playgo/playgo.cpp
+++ b/src/core/libraries/playgo/playgo.cpp
@@ -137,6 +137,9 @@ s32 PS4_SYSV_ABI scePlayGoGetLanguageMask(OrbisPlayGoHandle handle,
 
 s32 PS4_SYSV_ABI scePlayGoGetLocus(OrbisPlayGoHandle handle, const OrbisPlayGoChunkId* chunkIds,
                                    uint32_t numberOfEntries, OrbisPlayGoLocus* outLoci) {
+    LOG_DEBUG(Lib_PlayGo, "called handle = {}, chunkIds = {}, numberOfEntries = {}", handle,
+              *chunkIds, numberOfEntries);
+
     if (handle != PlaygoHandle) {
         return ORBIS_PLAYGO_ERROR_BAD_HANDLE;
     }
@@ -146,15 +149,11 @@ s32 PS4_SYSV_ABI scePlayGoGetLocus(OrbisPlayGoHandle handle, const OrbisPlayGoCh
     if (numberOfEntries == 0) {
         return ORBIS_PLAYGO_ERROR_BAD_SIZE;
     }
-
-    LOG_DEBUG(Lib_PlayGo, "called handle = {}, chunkIds = {}, numberOfEntries = {}", handle,
-              *chunkIds, numberOfEntries);
-
     if (!playgo) {
         return ORBIS_PLAYGO_ERROR_NOT_INITIALIZED;
     }
 
-    // Force LocalFast status for all queried chunks
+    // Return LocalFast status for all requested chunks unconditionally
     for (uint32_t i = 0; i < numberOfEntries; i++) {
         outLoci[i] = OrbisPlayGoLocus::LocalFast;
     }
@@ -180,7 +179,7 @@ s32 PS4_SYSV_ABI scePlayGoGetProgress(OrbisPlayGoHandle handle, const OrbisPlayG
         return ORBIS_PLAYGO_ERROR_NOT_INITIALIZED;
     }
 
-    // Report 100% progress with 1 GB fixed size
+    // Always report 100% download progress for any requested chunk
     outProgress->progressSize = 1073741824; // 1 GB
     outProgress->totalSize = 1073741824;
 

--- a/src/core/libraries/playgo/playgo.cpp
+++ b/src/core/libraries/playgo/playgo.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "common/config.h"
 #include "common/logging/log.h"
 #include "common/singleton.h"
 #include "core/file_format/playgo_chunk.h"
@@ -51,14 +52,19 @@ s32 PS4_SYSV_ABI scePlayGoGetChunkId(OrbisPlayGoHandle handle, OrbisPlayGoChunkI
         return ORBIS_PLAYGO_ERROR_BAD_SIZE;
     }
 
-    if (outChunkIdList == nullptr) {
-        *outEntries = (playgo && !playgo->chunks.empty()) ? playgo->chunks.size() : 1;
+    if (!Config::enablePlayGoFix() && playgo->GetPlaygoHeader().file_size == 0) {
+        *outEntries = 0;
         return ORBIS_OK;
     }
 
-    u32 total = (playgo && !playgo->chunks.empty()) ? playgo->chunks.size() : 1;
-    if (numberOfEntries > total) {
-        numberOfEntries = total;
+    if (outChunkIdList == nullptr) {
+        *outEntries = (playgo && !playgo->chunks.empty()) ? playgo->chunks.size() : (Config::enablePlayGoFix() ? 1 : 0);
+        return ORBIS_OK;
+    }
+
+    u32 total_chunks = (playgo && !playgo->chunks.empty()) ? playgo->chunks.size() : (Config::enablePlayGoFix() ? 1 : 0);
+    if (numberOfEntries > total_chunks) {
+        numberOfEntries = total_chunks;
     }
 
     for (u32 i = 0; i < numberOfEntries; i++) {
@@ -99,7 +105,22 @@ s32 PS4_SYSV_ABI scePlayGoGetInstallSpeed(OrbisPlayGoHandle handle,
         return ORBIS_PLAYGO_ERROR_NOT_INITIALIZED;
     }
 
-    *outSpeed = OrbisPlayGoInstallSpeed::Full;
+    if (Config::enablePlayGoFix()) {
+        *outSpeed = OrbisPlayGoInstallSpeed::Full;
+        return ORBIS_OK;
+    }
+
+    std::scoped_lock lk{playgo->GetSpeedMutex()};
+
+    if (playgo->speed == OrbisPlayGoInstallSpeed::Suspended) {
+        using namespace std::chrono;
+        if ((duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count() -
+             playgo->speed_tick) > 30 * 1000) { // 30sec
+            playgo->speed = OrbisPlayGoInstallSpeed::Trickle;
+        }
+    }
+    *outSpeed = playgo->speed;
+
     return ORBIS_OK;
 }
 
@@ -140,9 +161,26 @@ s32 PS4_SYSV_ABI scePlayGoGetLocus(OrbisPlayGoHandle handle, const OrbisPlayGoCh
         return ORBIS_PLAYGO_ERROR_NOT_INITIALIZED;
     }
 
-    // Force LocalFast for all queried chunks
+    // Workaround if the UI checkbox is enabled
+    if (Config::enablePlayGoFix()) {
+        for (uint32_t i = 0; i < numberOfEntries; i++) {
+            outLoci[i] = OrbisPlayGoLocus::LocalFast;
+        }
+        return ORBIS_OK;
+    }
+
+    // Original logic
+    if (playgo->GetPlaygoHeader().file_size == 0) {
+        return ORBIS_PLAYGO_ERROR_NOT_SUPPORT_PLAYGO;
+    }
+
     for (uint32_t i = 0; i < numberOfEntries; i++) {
-        outLoci[i] = OrbisPlayGoLocus::LocalFast;
+        if (chunkIds[i] < playgo->chunks.size()) {
+            outLoci[i] = OrbisPlayGoLocus::LocalFast;
+        } else {
+            outLoci[i] = OrbisPlayGoLocus::NotDownloaded;
+            return ORBIS_PLAYGO_ERROR_BAD_CHUNK_ID;
+        }
     }
     return ORBIS_OK;
 }
@@ -165,9 +203,33 @@ s32 PS4_SYSV_ABI scePlayGoGetProgress(OrbisPlayGoHandle handle, const OrbisPlayG
         return ORBIS_PLAYGO_ERROR_NOT_INITIALIZED;
     }
 
-    // Report 100% progress (1 GB fixed size)
-    outProgress->progressSize = 1073741824; // 1 GB
-    outProgress->totalSize = 1073741824;
+    // Workaround if the UI checkbox is enabled (Force dummy 100% progress)
+    if (Config::enablePlayGoFix()) {
+        outProgress->progressSize = 1073741824; // 1 GB
+        outProgress->totalSize = 1073741824;
+        return ORBIS_OK;
+    }
+
+    // Original logic
+    if (playgo->GetPlaygoHeader().file_size == 0) {
+        return ORBIS_PLAYGO_ERROR_BAD_CHUNK_ID;
+    }
+
+    outProgress->progressSize = 0;
+    outProgress->totalSize = 0;
+
+    u64 total_size = 0;
+    for (u32 i = 0; i < numberOfEntries; i++) {
+        u32 chunk_id = chunkIds[i];
+        if (chunk_id < playgo->chunks.size()) {
+            total_size += playgo->chunks[chunk_id].total_size;
+        } else {
+            return ORBIS_PLAYGO_ERROR_BAD_CHUNK_ID;
+        }
+    }
+
+    outProgress->progressSize = total_size;
+    outProgress->totalSize = total_size;
 
     return ORBIS_OK;
 }
@@ -242,7 +304,10 @@ s32 PS4_SYSV_ABI scePlayGoOpen(OrbisPlayGoHandle* outHandle, const void* param) 
         return ORBIS_PLAYGO_ERROR_NOT_INITIALIZED;
     }
 
-    // Allow opening library handle directly
+    if (!Config::enablePlayGoFix() && playgo->GetPlaygoHeader().file_size == 0) {
+        return ORBIS_PLAYGO_ERROR_NOT_SUPPORT_PLAYGO;
+    }
+
     playgo->handle = *outHandle = PlaygoHandle;
     return ORBIS_OK;
 }

--- a/src/core/libraries/playgo/playgo.cpp
+++ b/src/core/libraries/playgo/playgo.cpp
@@ -51,18 +51,14 @@ s32 PS4_SYSV_ABI scePlayGoGetChunkId(OrbisPlayGoHandle handle, OrbisPlayGoChunkI
         return ORBIS_PLAYGO_ERROR_BAD_SIZE;
     }
 
-    if (playgo->GetPlaygoHeader().file_size == 0) {
-        *outEntries = 0;
-        return ORBIS_OK;
-    }
-
     if (outChunkIdList == nullptr) {
-        *outEntries = playgo->chunks.size();
+        *outEntries = (playgo && !playgo->chunks.empty()) ? playgo->chunks.size() : 1;
         return ORBIS_OK;
     }
 
-    if (numberOfEntries > playgo->chunks.size()) {
-        numberOfEntries = playgo->chunks.size();
+    u32 total = (playgo && !playgo->chunks.empty()) ? playgo->chunks.size() : 1;
+    if (numberOfEntries > total) {
+        numberOfEntries = total;
     }
 
     for (u32 i = 0; i < numberOfEntries; i++) {
@@ -103,17 +99,7 @@ s32 PS4_SYSV_ABI scePlayGoGetInstallSpeed(OrbisPlayGoHandle handle,
         return ORBIS_PLAYGO_ERROR_NOT_INITIALIZED;
     }
 
-    std::scoped_lock lk{playgo->GetSpeedMutex()};
-
-    if (playgo->speed == OrbisPlayGoInstallSpeed::Suspended) {
-        using namespace std::chrono;
-        if ((duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count() -
-             playgo->speed_tick) > 30 * 1000) { // 30sec
-            playgo->speed = OrbisPlayGoInstallSpeed::Trickle;
-        }
-    }
-    *outSpeed = playgo->speed;
-
+    *outSpeed = OrbisPlayGoInstallSpeed::Full;
     return ORBIS_OK;
 }
 
@@ -137,9 +123,6 @@ s32 PS4_SYSV_ABI scePlayGoGetLanguageMask(OrbisPlayGoHandle handle,
 
 s32 PS4_SYSV_ABI scePlayGoGetLocus(OrbisPlayGoHandle handle, const OrbisPlayGoChunkId* chunkIds,
                                    uint32_t numberOfEntries, OrbisPlayGoLocus* outLoci) {
-    LOG_DEBUG(Lib_PlayGo, "called handle = {}, chunkIds = {}, numberOfEntries = {}", handle,
-              *chunkIds, numberOfEntries);
-
     if (handle != PlaygoHandle) {
         return ORBIS_PLAYGO_ERROR_BAD_HANDLE;
     }
@@ -149,15 +132,18 @@ s32 PS4_SYSV_ABI scePlayGoGetLocus(OrbisPlayGoHandle handle, const OrbisPlayGoCh
     if (numberOfEntries == 0) {
         return ORBIS_PLAYGO_ERROR_BAD_SIZE;
     }
+
+    LOG_DEBUG(Lib_PlayGo, "called handle = {}, chunkIds = {}, numberOfEntries = {}", handle,
+              *chunkIds, numberOfEntries);
+
     if (!playgo) {
         return ORBIS_PLAYGO_ERROR_NOT_INITIALIZED;
     }
 
-    // Return LocalFast status for all requested chunks unconditionally
+    // Force LocalFast for all queried chunks
     for (uint32_t i = 0; i < numberOfEntries; i++) {
         outLoci[i] = OrbisPlayGoLocus::LocalFast;
     }
-
     return ORBIS_OK;
 }
 
@@ -179,7 +165,7 @@ s32 PS4_SYSV_ABI scePlayGoGetProgress(OrbisPlayGoHandle handle, const OrbisPlayG
         return ORBIS_PLAYGO_ERROR_NOT_INITIALIZED;
     }
 
-    // Always report 100% download progress for any requested chunk
+    // Report 100% progress (1 GB fixed size)
     outProgress->progressSize = 1073741824; // 1 GB
     outProgress->totalSize = 1073741824;
 
@@ -255,10 +241,8 @@ s32 PS4_SYSV_ABI scePlayGoOpen(OrbisPlayGoHandle* outHandle, const void* param) 
     if (!playgo) {
         return ORBIS_PLAYGO_ERROR_NOT_INITIALIZED;
     }
-    if (playgo->GetPlaygoHeader().file_size == 0) {
-        return ORBIS_PLAYGO_ERROR_NOT_SUPPORT_PLAYGO;
-    }
 
+    // Allow opening library handle directly
     playgo->handle = *outHandle = PlaygoHandle;
     return ORBIS_OK;
 }

--- a/src/qt_gui/settings_dialog.cpp
+++ b/src/qt_gui/settings_dialog.cpp
@@ -458,6 +458,7 @@ SettingsDialog::SettingsDialog(std::shared_ptr<gui_settings> gui_settings,
         ui->showSplashCheckBox->installEventFilter(this);
         ui->discordRPCCheckbox->installEventFilter(this);
         ui->volumeSliderElement->installEventFilter(this);
+        ui->playgoFixCheckBox->installEventFilter(this);
 #ifdef ENABLE_UPDATER
         ui->updaterGroupBox->installEventFilter(this);
 #endif
@@ -628,6 +629,7 @@ void SettingsDialog::LoadValuesFromConfig() {
             toml::find_or<bool>(data, "General", "compatibilityEnabled", false));
         ui->checkCompatibilityOnStartupCheckBox->setChecked(
             toml::find_or<bool>(data, "General", "checkCompatibilityOnStartup", false));
+        ui->playgoFixCheckBox->setChecked(Config::enablePlayGoFix());
 
         ui->removeFolderButton->setEnabled(!ui->gameFoldersListWidget->selectedItems().isEmpty());
         ui->backgroundImageOpacitySlider->setValue(
@@ -854,6 +856,8 @@ void SettingsDialog::updateNoteTextEdit(const QString& elementName) {
         text = tr("Emulator Language:\\nSets the language of the emulator's user interface.");
     } else if (elementName == "showSplashCheckBox") {
         text = tr("Show Splash Screen:\\nShows the game's splash screen (a special image) while the game is starting.");
+    } else if (elementName == "playgoFixCheckBox") {
+        text = tr("Enable PlayGo Fix:\nEnables compatibility workaround for PlayGo package chunk installations.");
     } else if (elementName == "discordRPCCheckbox") {
         text = tr("Enable Discord Rich Presence:\\nDisplays the emulator icon and relevant information on your Discord profile.");
     } else if (elementName == "userName") {
@@ -1032,6 +1036,7 @@ void SettingsDialog::UpdateSettings(bool is_specific) {
                                          is_specific);
     Config::setisTrophyPopupDisabled(ui->disableTrophycheckBox->isChecked(), is_specific);
     Config::setTrophyNotificationDuration(ui->popUpDurationSpinBox->value(), is_specific);
+    Config::setEnablePlayGoFix(ui->playgoFixCheckBox->isChecked(), is_specific);
 
     if (ui->radioButton_Top->isChecked()) {
         Config::setSideTrophy("top", is_specific);

--- a/src/qt_gui/settings_dialog.ui
+++ b/src/qt_gui/settings_dialog.ui
@@ -211,6 +211,13 @@
                 </widget>
                </item>
                <item>
+                <widget class="QCheckBox" name="playgoFixCheckBox">
+                 <property name="text">
+                  <string>Enable PlayGo Fix</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <spacer name="verticalSpacer_9">
                  <property name="orientation">
                   <enum>Qt::Orientation::Vertical</enum>


### PR DESCRIPTION
This is a forced/temporary workaround specifically to make _**Rock Band 4 Base**_ playable when it gets locked in _**PlayGo's content downloading**_ state:

<img width="2160" height="1216" alt="Band4PlayGoBug" src="https://github.com/user-attachments/assets/a9ec178e-c0cf-4e57-b136-f300b5dae984" />

<img width="2160" height="1207" alt="Band4PlayGoBug2" src="https://github.com/user-attachments/assets/30d146e2-b302-48d7-894b-5c36583b2a3e" />


### Summary / Changes:
- **`scePlayGoGetLocus`**: Forces `LocalFast` locus status.
- **`scePlayGoGetProgress`**: Reports 100% download progress, so the game leaves PlayGo's content downloading loop state.
- **`scePlayGoGetChunkId`**: Fallback to report at least 1 chunk if `playgo-chunk.dat` is missing.

<img width="1080" height="602" alt="Band4Fix1" src="https://github.com/user-attachments/assets/d462eea1-5eb4-461b-a6e6-05a82a2cbcfc" />


> **Note:** This is a hardcoded stub fix intended **ONLY** for RB4 Base and does not affect or break **Rock Band Rivals** _`obviously`_.